### PR TITLE
freecad iges exported files compatibility

### DIFF
--- a/src/IxMilia.Iges/IgesFileReader.cs
+++ b/src/IxMilia.Iges/IgesFileReader.cs
@@ -243,7 +243,7 @@ namespace IxMilia.Iges
 
             int index = 0;
             ParseDelimiterCharacter(file, fullString, ref index, true); // 1
-            ParseDelimiterCharacter(file, fullString, ref index, false); // 2
+            ParseString(file, fullString, ref index); // 2
             file.Identification = ParseString(file, fullString, ref index); // 3
             file.FullFileName = ParseString(file, fullString, ref index); // 4
             file.SystemIdentifier = ParseString(file, fullString, ref index); // 5


### PR DESCRIPTION
Fix error when parse attached test iges file ( a simple cube 10x10x10 ) generated by freecad export
Error generates at [this line]([exception](https://github.com/IxMilia/Iges/blob/72bc66c55f4f6392edbc4c2f5d85e56dac4615ac/src/IxMilia.Iges/IgesFileReader.cs#L288) "Expected delimiter of length 1")

Tested compatibility with other online available iges [examples](http://3dgallery.gks.com/2015/bracket)

Freecad test file : [test.zip](https://github.com/IxMilia/Iges/files/2520496/test.zip)
