### PR TITLE
parse double fix

### DIFF
--- a/src/IxMilia.Iges/IgesParser.cs
+++ b/src/IxMilia.Iges/IgesParser.cs
@@ -6,7 +6,7 @@ namespace IxMilia.Iges
     {
         public static bool TryParseDouble(string s, out double result)
         {
-            return double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+            return double.TryParse(s.ToLower().Replace('d', 'e'), NumberStyles.Float, CultureInfo.InvariantCulture, out result);
         }
 
         public static double ParseDoubleOrDefault(string s, double defaultValue)
@@ -21,7 +21,7 @@ namespace IxMilia.Iges
 
         public static double ParseDoubleStrict(string s)
         {
-            return double.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture);
+            return double.Parse(s.ToLower().Replace('d', 'e'), NumberStyles.Float, CultureInfo.InvariantCulture);
         }
 
         public static bool TryParseInt(string s, out int result)


### PR DESCRIPTION
Allows to parse lines like this : "110,2.1D1,-1D1,-3.905D2,2.5D1,-1D1,-3.905D2;"